### PR TITLE
leaving private data and using relative paths

### DIFF
--- a/R/03_recreate_manuscript_results.Rmd
+++ b/R/03_recreate_manuscript_results.Rmd
@@ -32,7 +32,7 @@ rcol <- c(wes_palette("Darjeeling1"), wes_palette("Darjeeling2"))
 
 ```{r load_data}
 
-load("~/Desktop/test/results/ng_data.RData")
+load(here("results", "ng_data.RData"))
 
 ```
 
@@ -64,8 +64,7 @@ manuscriptList[which(abs(manuscriptList$logFC)>1.5),c("geneID","logFC","adj.P.Va
 
 length(unique(manuscriptList[,"geneID"]))
 
-#actualList <- read.csv(here("data", "supplementData.csv"),stringsAsFactors = FALSE)
-actualList <- read.csv("~/Desktop/test/data/supplementData.csv",stringsAsFactors = FALSE)
+actualList <- read.csv(here("data", "supplementData.csv"),stringsAsFactors = FALSE)
 rownames(actualList) <- paste(actualList$ILMN,as.character(actualList$illuminaID),sep="_")
 plot(actualList$logFC,manuscriptResults[rownames(actualList),"logFC"],pch=21,bg="dodgerblue",xlab="reported fold changes",ylab="recreation of fold changes")
 abline(a=0,b=1,col="red")

--- a/R/95_make_clean.R
+++ b/R/95_make_clean.R
@@ -7,7 +7,7 @@
 
 library(here)
 
-dirs_to_clean <- c("results", "data")
+dirs_to_clean <- c("results")
 
 for(i1 in 1:length(dirs_to_clean)){
   temp_file_list <- 


### PR DESCRIPTION
make clean currently gets rid of the author-supplied annotation files, which
aren't available elsewhere. I've restricted what they delete so this won't happen. 

script 03 needed to have some absolute paths changed to relative paths
(using here) before they would run on my machine.